### PR TITLE
Fixed bug with numeric value of font-weight

### DIFF
--- a/CanvasTextWrapper.js
+++ b/CanvasTextWrapper.js
@@ -52,7 +52,12 @@
 
 	CanvasTextWrapper.prototype = {
 		_init: function() {
-			this.fontSize = parseInt(this.font.replace(/^\D+/g,''),10) || 18;
+			/* Substituting this line that causing a bug with font-weight numeric values	*/
+			//this.fontSize = parseInt(this.font.replace(/^\D+/g,''),10) || 18;
+
+			/* This line allow font values like : "italic 500 25px" to preserve both numeric a literal value of font-weight*/
+			this.fontSize = this.font.match(/\d+(px|em|\%)/g) ? +this.font.match(/\d+(px|em|\%)/g)[0].match(/\d+/g) : 18;
+
 			this.textBlockHeight = 0;
 			this.lines = [];
 			this.newLineIndexes = [];


### PR DESCRIPTION
The line edited cause value of `font` like `italic 500 36px Aria` to treat `500` as `fontSize` instead of `font-weight`. Edited to handle such values.
Is needed a `Grunt` :)